### PR TITLE
return shiftImposedShear value

### DIFF
--- a/include/GooseEPM/System.h
+++ b/include/GooseEPM/System.h
@@ -697,7 +697,7 @@ public:
      *
      * @param direction Select positive (+1) or negative (-1) direction.
      */
-    void shiftImposedShear(int direction = 1)
+    double shiftImposedShear(int direction = 1)
     {
         double dsig;
 
@@ -709,6 +709,8 @@ public:
         }
 
         m_sig += dsig;
+
+        return dsig;
     }
 
     /**


### PR DESCRIPTION
Having direct access to this value makes it easier to obtain the correct stress-strain curve (without having to double the number of steps and duplicate unnecessarily every sampled property).